### PR TITLE
Add is completed option

### DIFF
--- a/MMM-Trello.css
+++ b/MMM-Trello.css
@@ -5,3 +5,7 @@
 .checklist-item {
     text-align: left;
 }
+
+.is-completed {
+    text-decoration: line-through;
+}

--- a/MMM-Trello.js
+++ b/MMM-Trello.js
@@ -22,7 +22,8 @@ Module.register("MMM-Trello", {
         showDueDate: true,
         showChecklists: true,
         showChecklistTitle: false,
-        wholeList: false
+        wholeList: false,
+        isCompleted: false
     },
 
     // Define start sequence.
@@ -102,6 +103,7 @@ Module.register("MMM-Trello", {
         return {
             en: "translations/en.json",
             de: "translations/de.json",
+            sv: "translations/sv.json",
             pl: "translations/pl.json"
         };
     },
@@ -127,7 +129,7 @@ Module.register("MMM-Trello", {
                 for (card = startat; card <= endat; card++) {
                     if (this.config.showTitle || this.config.showDueDate) {
                         var name = document.createElement("div");
-                        name.className = "bright medium light";
+                        name.className = "medium light " + (this.config.isCompleted ? "is-completed" : "bright");
 
                         content = "";
                         if (this.config.showTitle) {
@@ -148,7 +150,7 @@ Module.register("MMM-Trello", {
                         wrapper.appendChild(name);
                     }
                     var desc = document.createElement("div");
-                    desc.className = "small light";
+                    desc.className = "small light " + (this.config.isCompleted ? "is-completed dimmed" : "");
 
                     content = this.listContent[card].desc;
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>true</code>
 			</td>
 		</tr>
+    <tr>
+			<td><code>isCompleted</code></td>
+			<td>If list symbolizes a set of completed tasks then<br>enabling this option will strike-out titles.<br>
+				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
 		<tr>
 			<td><code>showLineBreaks</code></td>
 			<td>Display line breaks in the description? Needs more space if true.<br>

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1,0 +1,4 @@
+{
+    /* TRELLO */
+    "NO_CARDS": "Inga kort funna."
+}


### PR DESCRIPTION
Like others i know who use the magic-mirror i have need for using trello to show a list of completed tasks as well as a list of available tasks. I have added an option ```isCompleted``` that strikes out and dims the cards for a trello list. I took the liberty to add swedish translation for no cards found aswell. 