### PR TITLE
Ability to set how many cards to display

### DIFF
--- a/MMM-Trello.js
+++ b/MMM-Trello.js
@@ -24,7 +24,8 @@ Module.register("MMM-Trello", {
         showChecklists: true,
         showChecklistTitle: false,
         wholeList: false,
-        isCompleted: false
+        isCompleted: false,
+        numberOfCardsToDisplay: 1, // to be able to show more than 1, but not the whole list
     },
 
     // Define start sequence.
@@ -127,6 +128,16 @@ Module.register("MMM-Trello", {
                     startat = this.activeItem;
                     endat = this.activeItem;
                 }
+
+                // Adding code here to be able to show n number of cards (more than 1, but not the whole list)
+                if (this.config.numberOfCardsToDisplay > 1 && this.config.numberOfCardsToDisplay > this.listContent.length) {
+                  endat = this.listContent.length - 1;
+                }
+                if (this.config.numberOfCardsToDisplay > 1 && this.config.numberOfCardsToDisplay <= this.listContent.length) {
+                  endat = this.config.numberOfCardsToDisplay - 1;
+                }
+                // end of added code to handle displaying a n number of cards
+
                 for (card = startat; card <= endat; card++) {
                     if (this.config.showTitle || this.config.showDueDate) {
                         var name = document.createElement("div");


### PR DESCRIPTION
# Description
Originally, it only displays 1 card, unless you configure to show the whole list. If you have a big list, but would like to see more than just 1 card, then this PR adds this capability. You can set numberOfCardsToDisplay = 4 (whatever number of cards you want to see it).


## Commit comments
Adds minimum code necessary to be able to display a number of cards, more than 1 and not the whole list. Created new config option: numberOfCardsToDisplay.